### PR TITLE
Simplified session handling....

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,13 +75,8 @@ module.exports = function(config) {
         }
 
         delete user.salt;
-        req.session.regenerate(function() {
-          req.session.user = user;
-          req.session.save();
-
-          res.writeHead(200, { 'set-cookie': headers['set-cookie']});
-          res.end(JSON.stringify({ok:true, user: strip(user)}));
-        });
+        req.session.user = user;
+        res.end(JSON.stringify({ok:true, user: strip(user)}));
       });
     }
   });


### PR DESCRIPTION
express-session will actually take care of generating the session for us, and the way that we send the cookie headers ourselves clobbers whatever session cookie the user has configured in their app.  Among other things, this means the user can't control the name of the cookie, etc. upstream.  It also doesn't seem to work with express 4.x.

This pull request greatly simplifies the handling by basically leaving session creation and persistence to express-session.  It also gets session handling working in express 4.x.
