### PR TITLE
Added optional authentication check for nano

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,23 @@ var only = require('only');
 module.exports = function(config) {
   var app = express();
   var safeUserFields = config.safeUserFields ? config.safeUserFields : "name email roles";
-  var db = nano(config.users);
+  
+  // Use nano auth if you pass in a user to authenticate with
+  if(config.couch_username && config.couch_password) {
+    var db = nano({
+      url: config.users,
+      request_defaults: {
+        auth: {
+          username: config.couch_username,
+          password: config.couch_password
+        },
+        strictSSL: false
+      }
+    });
+  } else {
+    var db = nano(config.users);
+  }
+
   var transport;  
   try {
     transport = nodemailer.createTransport(


### PR DESCRIPTION
### Issue

Currently if this module is used with a couchDB that requires an authorized user to make requests it will fail to complete the request.
### Solution

Added a hook for nano to be configured with a couchDB Admin for authentication if the information is passed in via the config variables 'couch_username' and 'couch_password', otherwise nano will be configured as normal.
