### PR TITLE
Move sending of responses inside destroy callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 testServer
 coverage/*
+.idea/

--- a/test/userSpec.js
+++ b/test/userSpec.js
@@ -401,7 +401,8 @@ describe('User API Tests', function() {
             var obj = JSON.parse(r.text);
             expect(obj.ok).to.eql(true);
             expect(obj.message).to.eql('User adminUser deleted.');
-            callSessionAfter(r.headers['set-cookie'][0]); 
+            expect(r.headers['set-cookie']).to.not.be.ok();
+            callSessionAfter(cookie);
           });
       }
 


### PR DESCRIPTION
Making sure that when session.destroy is called that the response is not sent until after the destroy has completed.
