### PR TITLE
Add fallback to find user name when server admins login

### DIFF
--- a/test/validateUserSigninSpec.js
+++ b/test/validateUserSigninSpec.js
@@ -19,7 +19,7 @@ describe('login with validateUser test', function() {
           statusCode: 403,
           message: 'Exceeded fail login attempts', 
           error: 'Forbidden'
-        }
+        };
         cb(errorPayload);
       } else {
         cb(null);
@@ -56,8 +56,8 @@ describe('login with validateUser test', function() {
 
     var getResponse = {
       name: 'foo',
-      failedLogin: 6,
-    }
+      failedLogin: 6
+    };
 
     nock('http://localhost:5984')
       .get('/_user/org.couchdb.user%3Afoo')
@@ -87,8 +87,8 @@ describe('login with validateUser test', function() {
 
     var getResponse = {
       name: 'foo',
-      failedLogin: 4,
-    }
+      failedLogin: 4
+    };
 
     nock('http://localhost:5984')
       .get('/_user/org.couchdb.user%3Afoo')


### PR DESCRIPTION
Added a hook to prevent Couch Server Admins from logging in.  They will be shown the same error that is shown when a user incorrectly inputs their username or password.

Previously when a Couch Server Admin attempted to login they were presented with a error message than the document was missing. 
